### PR TITLE
Improving the rncType function by returning the Types enum.

### DIFF
--- a/src/DgiiRncValidator.php
+++ b/src/DgiiRncValidator.php
@@ -21,10 +21,10 @@ class DgiiRncValidator
         return (bool) count($matches);
     }
 
-    public static function rncType(string $string): bool|string
+    public static function rncType(string $string): bool|Types
     {
         if (self::validateRNC($string)) {
-            return (strlen($string) === 9) ? Types::RNC->toString() : Types::CEDULA->toString();
+            return (strlen($string) === 9) ? Types::RNC : Types::CEDULA;
         }
 
         return false;

--- a/src/helpers/Types.php
+++ b/src/helpers/Types.php
@@ -18,4 +18,13 @@ enum Types: int
             self::PASSPORT => 'PASSPORT',
         };
     }
+
+    public function toCode(): string
+    {
+        return match ($this) {
+            self::RNC => '01',
+            self::CEDULA => '02',
+            self::PASSPORT => '03',
+        };
+    }
 }

--- a/tests/DgiiRncValidatorTest.php
+++ b/tests/DgiiRncValidatorTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Seisigma\DgiiRncValidator\DgiiRncValidator;
+use Seisigma\DgiiRncValidator\helpers\Types;
 
 test('check if the given string is a valid RNC', function () {
     expect(DgiiRncValidator::validateRNC('123'))->toBeFalse()
@@ -10,8 +11,8 @@ test('check if the given string is a valid RNC', function () {
 });
 
 test('check rncType return the type name', function () {
-    expect(DgiiRncValidator::rncType('123456789'))->toBe('RNC')
-        ->and(DgiiRncValidator::rncType('12345678901'))->toBe('CEDULA');
+    expect(DgiiRncValidator::rncType('123456789'))->toBe(Types::RNC)
+        ->and(DgiiRncValidator::rncType('12345678901'))->toBe(Types::CEDULA);
 });
 
 it('can return the details of an RNC if true', function () {


### PR DESCRIPTION
- Using Enum returns over direct values in the `rncType` function on the DgiiRncValidator library.
- Adding the `toCode` method to the Types enum.